### PR TITLE
we don't rely on TPM to scan configuration files anymore...

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1483,13 +1483,12 @@ run 'cut -c3- "$TMUX_CONF" | sh -s _apply_configuration'
 #     fi
 #   else
 #     if [ "$(command tmux display -p '#{pid} #{version} #{socket_path}')" = "$($TMUX_PROGRAM display -p '#{pid} #{version} #{socket_path}')" ]; then
-#       if git ls-remote -hq https://github.com/gpakosz/.tmux.git master > /dev/null; then
-#         tpm_plugins=$(cat << EOF | tr ' ' '\n' | awk '/^\s*$/ {next;}; !seen[$0]++ { gsub(/^[ \t]+/,"",$0); gsub(/[ \t]+$/,"",$0); print $0 }'
-#           $(awk '/^[ \t]*set(-option)?.*[ \t]@plugin[ \t]/ { gsub(/'\''/, ""); gsub(/'\"'/, ""); print $NF }' "$TMUX_CONF_LOCAL" 2>/dev/null)
+#       tpm_plugins=$(cat << EOF | tr ' ' '\n' | awk '/^\s*$/ {next;}; !seen[$0]++ { gsub(/^[ \t]+/,"",$0); gsub(/[ \t]+$/,"",$0); print $0 }'
+#         $(awk '/^[ \t]*set(-option)?.*[ \t]@plugin[ \t]/ { gsub(/'\''/, ""); gsub(/'\"'/, ""); print $NF }' "$TMUX_CONF_LOCAL" 2>/dev/null)
 # EOF
-#         )
-#         tmux set -g '@tpm_plugins' "$tpm_plugins"
-#
+#       )
+#       tmux set -g '@tpm_plugins' "$tpm_plugins"
+#       if git ls-remote -hq https://github.com/gpakosz/.tmux.git master > /dev/null; then
 #         if [ ! -d "$TMUX_PLUGIN_MANAGER_PATH/tpm" ]; then
 #           install_tpm=true
 #           tmux display 'Installing tpm and plugins...'


### PR DESCRIPTION
as such we need to populate the @tpm_plugins outside of the internet connectivity check , otherwise TPM loads no plugin at all

fixes #637