### PR TITLE
introduced tmux_conf_new_session_retain_current_path (2)

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -946,7 +946,7 @@ run 'cut -c3- "$TMUX_CONF" | sh -s _apply_configuration'
 #     perl -p -i -e "s/\bcommand-prompt\s+-p\s+new-session\s+\"new-session\s+-s\s+'%%'\"/new-session/g" "$cfg"
 #   fi
 #
-#   tmux_conf_new_session_retain_current_path=${tmux_conf_new_session_retain_current_path:-true}
+#   tmux_conf_new_session_retain_current_path=${tmux_conf_new_session_retain_current_path:-false}
 #   if ! _is_disabled "$tmux_conf_new_session_retain_current_path" && _is_true "$tmux_conf_new_session_retain_current_path"; then
 #     perl -p -i -e "
 #       s/(?<!\bcommand-prompt -p )\bnew-session\b/new-session -c '#{pane_current_path}'/g" \


### PR DESCRIPTION
tmux_conf_new_session_retain_current_path should be false by default